### PR TITLE
File Chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/Santiago-Labs/go-ocsf/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Santiago-Labs/go-ocsf/actions/workflows/ci.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/Santiago-Labs/go-ocsf.svg)](https://pkg.go.dev/github.com/Santiago-Labs/go-ocsf)
-[![License](https://img.shields.io/github/license/Santiago-Labs/go-ocsf.svg)](LICENSE)
+[![License](https://img.shields.io/github/license/Santiago-Labs/go-ocsf)](LICENSE)
 
 `go-ocsf` is a Go library and CLI tool for converting security events from your security tools (e.g., Snyk) into the [Open Cybersecurity Schema Framework (OCSF)](https://schema.ocsf.io/) format, with output options in JSON or Parquet formats. Data can be stored locally or seamlessly uploaded to AWS S3.
 
@@ -11,7 +11,7 @@
 - ⚙️ Converts security event data into OCSF-compliant format
 - 📦 Supports JSON and Parquet output formats
 - ☁️ Direct integration with AWS S3 for cloud storage
-- 🖥️ Simple CLI tool and Go library usage
+- 🖥️ Use as a CLI tool or Go library
 
 ## Installation
 
@@ -40,6 +40,7 @@ Store data directly in AWS S3:
 export AWS_ACCESS_KEY_ID="your-aws-access-key-id"
 export AWS_SECRET_ACCESS_KEY="your-aws-secret-access-key"
 export AWS_REGION="your-aws-region"
+
 go run main.go --parquet --bucket-name="your-s3-bucket-name"
 ```
 
@@ -84,12 +85,13 @@ func main() {
 }
 ```
 
-## Supported Tools
+## Supported Integrations
 
 - Snyk
 - AWS Inspector (coming soon)
 - AWS GuardDuty (coming soon)
 - Crowdstrike Falcon (coming soon)
+- Google Workspace Logs (coming soon)
 - Tenable (coming soon)
 - AWS CloudTrail (coming soon)
 
@@ -105,4 +107,4 @@ We welcome contributions to improve or expand functionality.
 
 ## License
 
-`go-ocsf` is licensed under the [AGPL License](LICENSE).
+`go-ocsf` is licensed under the [AGPL-3.0 License](LICENSE).

--- a/clients/snyk/client.go
+++ b/clients/snyk/client.go
@@ -1,3 +1,6 @@
+// Package snyk provides a client for interacting with the Snyk API.
+// The Snyk API is documented at https://snyk.docs.apiary.io/
+
 package snyk
 
 import (
@@ -11,13 +14,18 @@ import (
 	"encoding/json"
 )
 
+// Client represents a Snyk API client that can interact with Snyk resources.
+// It handles authentication and communication with the Snyk API.
 type Client struct {
 	orgID      string
 	apiKey     string
 	httpClient *http.Client
 }
 
-func NewClient(ctx context.Context, apiKey, snykOrgID string) (*Client, error) {
+// NewClient creates a new Snyk client with the provided API key and organization ID.
+// It requires an API key and Snyk organization ID.
+// Returns an initialized client and any error encountered during initialization.
+func NewClient(apiKey, snykOrgID string) (*Client, error) {
 	return &Client{
 		apiKey:     apiKey,
 		httpClient: &http.Client{},
@@ -25,6 +33,7 @@ func NewClient(ctx context.Context, apiKey, snykOrgID string) (*Client, error) {
 	}, nil
 }
 
+// GetOrg retrieves information about the Snyk organization associated with this client.
 func (c *Client) GetOrg(ctx context.Context) (*Org, error) {
 	url := fmt.Sprintf("https://api.snyk.io/rest/orgs/%s?version=2024-10-15", c.orgID)
 
@@ -57,6 +66,7 @@ func (c *Client) GetOrg(ctx context.Context) (*Org, error) {
 	return &org.Data, nil
 }
 
+// GetProject retrieves information about a specific Snyk project.
 func (c *Client) GetProject(ctx context.Context, projectID string) (*Project, error) {
 	url := fmt.Sprintf("https://api.snyk.io/rest/orgs/%s/projects/%s?version=2024-10-15", c.orgID, projectID)
 
@@ -89,6 +99,7 @@ func (c *Client) GetProject(ctx context.Context, projectID string) (*Project, er
 	return &project.Data, nil
 }
 
+// ParseSnykTestFile reads and parses a Snyk test result file from the specified filepath.
 func (c *Client) ParseSnykTestFile(ctx context.Context, filepath string) (SnykTestAllProjectsResult, error) {
 	jsonFile, err := os.ReadFile(filepath)
 	if err != nil {
@@ -102,6 +113,7 @@ func (c *Client) ParseSnykTestFile(ctx context.Context, filepath string) (SnykTe
 	return snykTestResult, nil
 }
 
+// ListIssues retrieves all vulnerability issues from the Snyk organization.
 func (c *Client) ListIssues(ctx context.Context) ([]Issue, error) {
 	var allIssues []Issue
 
@@ -154,6 +166,7 @@ func (c *Client) ListIssues(ctx context.Context) ([]Issue, error) {
 	return allIssues, nil
 }
 
+// GetIssue retrieves detailed information about a specific vulnerability issue.
 func (c *Client) GetIssue(ctx context.Context, issueID string) (*Issue, error) {
 	url := fmt.Sprintf("https://api.snyk.io/rest/orgs/%s/issues/%s?version=2024-06-10", c.orgID, issueID)
 

--- a/datastore/base.go
+++ b/datastore/base.go
@@ -15,6 +15,7 @@ type BaseDatastore struct {
 	store Datastore
 }
 
+// GetFinding returns a single finding from the datastore or ErrNotFound if the finding is not found
 func (d *BaseDatastore) GetFinding(ctx context.Context, findingID string) (*ocsf.VulnerabilityFinding, error) {
 	filePath, exists := d.findingIndex[findingID]
 	if !exists {
@@ -35,6 +36,7 @@ func (d *BaseDatastore) GetFinding(ctx context.Context, findingID string) (*ocsf
 	return nil, ErrNotFound
 }
 
+// SaveFindings saves a batch of findings to the datastore. Datastore implementations handle file formats.
 func (d *BaseDatastore) SaveFindings(ctx context.Context, findings []ocsf.VulnerabilityFinding) error {
 	var (
 		currentBatch     []ocsf.VulnerabilityFinding

--- a/datastore/base.go
+++ b/datastore/base.go
@@ -1,0 +1,93 @@
+package datastore
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/Santiago-Labs/go-ocsf/ocsf"
+	"github.com/samsarahq/go/oops"
+)
+
+type BaseDatastore struct {
+	findingIndex map[string]string // findingID -> filePath
+	fileIndex    map[string]int    // filePath -> len(findings)
+
+	store Datastore
+}
+
+func (d *BaseDatastore) GetFinding(ctx context.Context, findingID string) (*ocsf.VulnerabilityFinding, error) {
+	filePath, exists := d.findingIndex[findingID]
+	if !exists {
+		return nil, ErrNotFound
+	}
+
+	findings, err := d.store.GetFindingsFromFile(ctx, filePath)
+	if err != nil {
+		return nil, oops.Wrapf(err, "failed to get all findings")
+	}
+
+	for _, finding := range findings {
+		if finding.FindingInfo.UID == findingID {
+			return &finding, nil
+		}
+	}
+
+	return nil, ErrNotFound
+}
+
+func (d *BaseDatastore) SaveFindings(ctx context.Context, findings []ocsf.VulnerabilityFinding) error {
+	var (
+		currentBatch     []ocsf.VulnerabilityFinding
+		currentBatchSize int
+	)
+
+	for _, finding := range findings {
+		if currentBatchSize > maxFileSize && len(currentBatch) > 0 {
+			pathWithSpace := d.getPathWithSpace(len(currentBatch))
+			if err := d.store.WriteBatch(ctx, currentBatch, pathWithSpace); err != nil {
+				return err
+			}
+			currentBatch = []ocsf.VulnerabilityFinding{}
+			currentBatchSize = 0
+		}
+
+		currentBatch = append(currentBatch, finding)
+		currentBatchSize += avgFindingSize
+	}
+
+	if len(currentBatch) > 0 {
+		pathWithSpace := d.getPathWithSpace(len(currentBatch))
+		if err := d.store.WriteBatch(ctx, currentBatch, pathWithSpace); err != nil {
+			return err
+		}
+	}
+
+	slog.Info("saved findings", "findings", len(findings))
+
+	return nil
+}
+
+func (d *BaseDatastore) getPathWithSpace(batchSize int) *string {
+	for path, count := range d.fileIndex {
+		if (count+batchSize)*avgFindingSize < maxFileSize {
+			return &path
+		}
+	}
+
+	return nil
+}
+
+func (d *BaseDatastore) loadFileIntoIndex(ctx context.Context, key string) error {
+	findings, err := d.store.GetFindingsFromFile(ctx, key)
+	if err != nil {
+		return oops.Wrapf(err, "failed to read all findings from parquet file")
+	}
+
+	for _, finding := range findings {
+		d.findingIndex[finding.FindingInfo.UID] = key
+	}
+	d.fileIndex[key] = len(findings)
+
+	slog.Debug("indexed findings from file", "key", key, "count", len(findings))
+	return nil
+}

--- a/datastore/localjson.go
+++ b/datastore/localjson.go
@@ -62,7 +62,6 @@ func (s *localJsonDatastore) GetFindingsFromFile(ctx context.Context, path strin
 
 // WriteBatch creates a new JSON file for storing vulnerability findings.
 // It marshals the findings into a JSON object and writes it to the specified file path.
-// The datastore also updates its in-memory index of finding IDs to file paths.
 func (s *localJsonDatastore) WriteBatch(ctx context.Context, findings []ocsf.VulnerabilityFinding, path *string) error {
 	allFindings := findings
 	if path == nil {

--- a/datastore/localparquet.go
+++ b/datastore/localparquet.go
@@ -15,12 +15,17 @@ import (
 )
 
 type localParquetDatastore struct {
-	findingIndex map[string]string
+	BaseDatastore
 }
 
+// NewLocalParquetDatastore creates a new local Parquet datastore.
+// It initializes an in-memory index of finding IDs to file paths.
 func NewLocalParquetDatastore() (Datastore, error) {
-	s := &localParquetDatastore{
+	s := &localParquetDatastore{}
+	s.BaseDatastore = BaseDatastore{
 		findingIndex: make(map[string]string),
+		fileIndex:    make(map[string]int),
+		store:        s,
 	}
 
 	if err := os.MkdirAll(basepath, 0755); err != nil {
@@ -35,6 +40,7 @@ func NewLocalParquetDatastore() (Datastore, error) {
 	return s, nil
 }
 
+// buildFindingIndex builds the datastore's in-memory index of finding IDs to file paths.
 func (s *localParquetDatastore) buildFindingIndex(ctx context.Context) error {
 	files, err := os.ReadDir(basepath)
 	if err != nil {
@@ -53,31 +59,13 @@ func (s *localParquetDatastore) buildFindingIndex(ctx context.Context) error {
 		}
 	}
 
-	slog.Info("built finding index from local files", "count", len(s.findingIndex))
+	slog.Info("built finding index from local files", "count", len(s.BaseDatastore.findingIndex))
 	return nil
 }
 
-func (s *localParquetDatastore) GetFinding(ctx context.Context, findingID string) (*ocsf.VulnerabilityFinding, error) {
-	filePath, exists := s.findingIndex[findingID]
-	if !exists {
-		return nil, ErrNotFound
-	}
-
-	findings, err := s.GetAllFindings(ctx, filePath)
-	if err != nil {
-		return nil, oops.Wrapf(err, "failed to get all findings")
-	}
-
-	for _, finding := range findings {
-		if finding.FindingInfo.UID == findingID {
-			return &finding, nil
-		}
-	}
-
-	return nil, ErrNotFound
-}
-
-func (s *localParquetDatastore) GetAllFindings(ctx context.Context, path string) ([]ocsf.VulnerabilityFinding, error) {
+// GetFindingsFromFile retrieves all vulnerability findings from a specific file path.
+// It reads the Parquet file and parses it into a slice of vulnerability findings.
+func (s *localParquetDatastore) GetFindingsFromFile(ctx context.Context, path string) ([]ocsf.VulnerabilityFinding, error) {
 	findings, err := goParquet.ReadFile[ocsf.VulnerabilityFinding](path)
 	if err != nil {
 		return nil, oops.Wrapf(err, "failed to read parquet file")
@@ -86,106 +74,36 @@ func (s *localParquetDatastore) GetAllFindings(ctx context.Context, path string)
 	return findings, nil
 }
 
-func (s *localParquetDatastore) SaveFindings(ctx context.Context, findings []ocsf.VulnerabilityFinding) error {
-	newFindings := []ocsf.VulnerabilityFinding{}
-	existingFindings := make(map[string][]ocsf.VulnerabilityFinding)
-
-	for _, finding := range findings {
-		filePath, exists := s.findingIndex[finding.FindingInfo.UID]
-		if !exists {
-			newFindings = append(newFindings, finding)
-		} else {
-			existingFindings[filePath] = append(existingFindings[filePath], finding)
+// createFile creates a new Parquet file for storing vulnerability findings.
+// It writes the findings to the specified file path and updates the datastore's in-memory index.
+func (s *localParquetDatastore) WriteBatch(ctx context.Context, findings []ocsf.VulnerabilityFinding, path *string) error {
+	allFindings := findings
+	if path == nil {
+		newpath := filepath.Join(basepath, fmt.Sprintf("%s.parquet", time.Now().Format("20060102T150405Z")))
+		path = &newpath
+	} else {
+		var err error
+		allFindings, err = s.GetFindingsFromFile(ctx, *path)
+		if err != nil {
+			return oops.Wrapf(err, "failed to get existing findings from disk")
 		}
+
+		allFindings = append(allFindings, findings...)
 	}
 
-	newFindingsFilename := fmt.Sprintf("%s.parquet", time.Now().Format("20060102T150405Z"))
-	newFindingsPath := filepath.Join(basepath, newFindingsFilename)
-
-	if len(newFindings) > 0 {
-		if err := s.createFile(ctx, newFindingsPath, newFindings); err != nil {
-			return oops.Wrapf(err, "failed to write new findings to parquet")
-		}
-	}
-
-	updatedCount := 0
-	for updatedFindingsPath, updatedFindings := range existingFindings {
-		if err := s.updateFile(ctx, updatedFindingsPath, updatedFindings); err != nil {
-			slog.Error("failed to update parquet file", "file", updatedFindingsPath, "error", err)
-			// Fall back to creating a new file for these findings
-
-			newFindingsFilename := fmt.Sprintf("%s.parquet", time.Now().Format("20060102T150405Z"))
-			newFindingsPath := filepath.Join(basepath, newFindingsFilename)
-			if err := s.createFile(ctx, newFindingsPath, updatedFindings); err != nil {
-				return oops.Wrapf(err, "failed to write fallback parquet file")
-			}
-		} else {
-			updatedCount += len(updatedFindings)
-		}
-	}
-
-	slog.Info("saved findings",
-		"new", len(newFindings),
-		"updated", updatedCount)
-
-	return nil
-}
-
-func (s *localParquetDatastore) createFile(ctx context.Context, filepath string, findings []ocsf.VulnerabilityFinding) error {
-	err := goParquet.WriteFile(filepath, findings)
+	err := goParquet.WriteFile(*path, allFindings)
 	if err != nil {
 		return oops.Wrapf(err, "failed to write findings to parquet")
 	}
 
-	for _, f := range findings {
-		s.findingIndex[f.FindingInfo.UID] = filepath
+	for _, f := range allFindings {
+		s.BaseDatastore.findingIndex[f.FindingInfo.UID] = *path
 	}
+	s.BaseDatastore.fileIndex[*path] = len(allFindings)
 
 	slog.Info("Wrote Parquet file to disk",
-		"path", filepath,
-		"findings", len(findings))
-	return nil
-}
-func (s *localParquetDatastore) loadFileIntoIndex(ctx context.Context, path string) error {
-	findings, err := s.GetAllFindings(ctx, path)
-	if err != nil {
-		return oops.Wrapf(err, "failed to read all findings from parquet file")
-	}
-
-	for _, finding := range findings {
-		s.findingIndex[finding.FindingInfo.UID] = path
-	}
-
-	slog.Debug("indexed findings from file", "path", path, "count", len(findings))
-	return nil
-}
-
-func (s *localParquetDatastore) updateFile(ctx context.Context, filePath string, updatedFindings []ocsf.VulnerabilityFinding) error {
-	updateMap := make(map[string]ocsf.VulnerabilityFinding)
-	for _, finding := range updatedFindings {
-		updateMap[finding.FindingInfo.UID] = finding
-	}
-
-	allFindings, err := s.GetAllFindings(ctx, filePath)
-	if err != nil {
-		return oops.Wrapf(err, "failed to read all findings from parquet file")
-	}
-
-	for i, finding := range allFindings {
-		if updated, exists := updateMap[finding.FindingInfo.UID]; exists {
-			allFindings[i] = updated
-			slog.Debug("updated finding in memory", "id", finding.FindingInfo.UID)
-		}
-	}
-
-	err = goParquet.WriteFile(filePath, allFindings)
-	if err != nil {
-		return oops.Wrapf(err, "failed to write findings to parquet")
-	}
-
-	slog.Info("replaced parquet file on disk",
-		"path", filePath,
-		"findings", len(updatedFindings))
-
+		"path", *path,
+		"findings", len(allFindings),
+	)
 	return nil
 }

--- a/datastore/localparquet.go
+++ b/datastore/localparquet.go
@@ -41,6 +41,7 @@ func NewLocalParquetDatastore() (Datastore, error) {
 }
 
 // buildFindingIndex builds the datastore's in-memory index of finding IDs to file paths.
+// It reads all Parquet files in the base directory and parses them into a slice of vulnerability findings.
 func (s *localParquetDatastore) buildFindingIndex(ctx context.Context) error {
 	files, err := os.ReadDir(basepath)
 	if err != nil {

--- a/datastore/s3json.go
+++ b/datastore/s3json.go
@@ -73,6 +73,8 @@ func (s *s3JsonDatastore) GetFindingsFromFile(ctx context.Context, key string) (
 	return findings.VulnerabilityFindings, nil
 }
 
+// WriteBatch creates a new JSON file for storing vulnerability findings.
+// It marshals the findings into a JSON object and writes it to the specified file path.
 func (s *s3JsonDatastore) WriteBatch(ctx context.Context, findings []ocsf.VulnerabilityFinding, key *string) error {
 	allFindings := findings
 	if key == nil {
@@ -119,6 +121,8 @@ func (s *s3JsonDatastore) WriteBatch(ctx context.Context, findings []ocsf.Vulner
 	return nil
 }
 
+// buildFindingIndex builds the datastore's in-memory index of finding IDs to file paths.
+// It reads all JSON files in the S3 bucket and parses them into a slice of vulnerability findings.
 func (s *s3JsonDatastore) buildFindingIndex(ctx context.Context) error {
 	paginator := s3.NewListObjectsV2Paginator(s.s3Client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.s3Bucket),

--- a/datastore/s3parquet.go
+++ b/datastore/s3parquet.go
@@ -21,15 +21,20 @@ type s3ParquetDatastore struct {
 	s3Bucket string
 	s3Client *s3.Client
 
-	findingIndex map[string]string
+	BaseDatastore
 }
 
+// NewS3ParquetDatastore creates a new S3 Parquet datastore.
+// It initializes an in-memory index of finding IDs to file paths.
 func NewS3ParquetDatastore(bucketName string, s3Client *s3.Client) Datastore {
 	s := &s3ParquetDatastore{
 		s3Bucket: bucketName,
 		s3Client: s3Client,
-
+	}
+	s.BaseDatastore = BaseDatastore{
 		findingIndex: make(map[string]string),
+		fileIndex:    make(map[string]int),
+		store:        s,
 	}
 
 	ctx := context.Background()
@@ -40,6 +45,9 @@ func NewS3ParquetDatastore(bucketName string, s3Client *s3.Client) Datastore {
 	return s
 }
 
+// buildFindingIndex builds the datastore's in-memory index of finding IDs to file paths.
+// It reads all Parquet files in the base directory and parses them into a slice of vulnerability findings.
+// The datastore updates its in-memory index with the finding IDs and their corresponding file paths.
 func (s *s3ParquetDatastore) buildFindingIndex(ctx context.Context) error {
 	paginator := s3.NewListObjectsV2Paginator(s.s3Client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.s3Bucket),
@@ -63,31 +71,13 @@ func (s *s3ParquetDatastore) buildFindingIndex(ctx context.Context) error {
 		}
 	}
 
-	slog.Info("built finding index from S3", "count", len(s.findingIndex))
+	slog.Info("built finding index from S3", "count", len(s.BaseDatastore.findingIndex))
 	return nil
 }
 
-func (s *s3ParquetDatastore) GetFinding(ctx context.Context, findingID string) (*ocsf.VulnerabilityFinding, error) {
-	filePath, exists := s.findingIndex[findingID]
-	if !exists {
-		return nil, ErrNotFound
-	}
-
-	findings, err := s.GetAllFindings(ctx, filePath)
-	if err != nil {
-		return nil, oops.Wrapf(err, "failed to get all findings")
-	}
-
-	for _, finding := range findings {
-		if finding.FindingInfo.UID == findingID {
-			return &finding, nil
-		}
-	}
-
-	return nil, ErrNotFound
-}
-
-func (s *s3ParquetDatastore) GetAllFindings(ctx context.Context, key string) ([]ocsf.VulnerabilityFinding, error) {
+// GetFindingsFromFile retrieves all vulnerability findings from a specific file path.
+// It reads the Parquet file and parses it into a slice of vulnerability findings.
+func (s *s3ParquetDatastore) GetFindingsFromFile(ctx context.Context, key string) ([]ocsf.VulnerabilityFinding, error) {
 	result, err := s.s3Client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(s.s3Bucket),
 		Key:    aws.String(key),
@@ -110,107 +100,19 @@ func (s *s3ParquetDatastore) GetAllFindings(ctx context.Context, key string) ([]
 	return findings, nil
 }
 
-func (s *s3ParquetDatastore) SaveFindings(ctx context.Context, findings []ocsf.VulnerabilityFinding) error {
-	newFindings := []ocsf.VulnerabilityFinding{}
-	existingFindings := make(map[string][]ocsf.VulnerabilityFinding)
-
-	for _, finding := range findings {
-		filePath, exists := s.findingIndex[finding.FindingInfo.UID]
-		if !exists {
-			newFindings = append(newFindings, finding)
-		} else {
-			existingFindings[filePath] = append(existingFindings[filePath], finding)
+func (s *s3ParquetDatastore) WriteBatch(ctx context.Context, findings []ocsf.VulnerabilityFinding, key *string) error {
+	allFindings := findings
+	if key == nil {
+		newkey := filepath.Join(basepath, fmt.Sprintf("%s.parquet", time.Now().Format("20060102T150405Z")))
+		key = &newkey
+	} else {
+		var err error
+		allFindings, err = s.GetFindingsFromFile(ctx, *key)
+		if err != nil {
+			return oops.Wrapf(err, "failed to get existing findings from disk")
 		}
-	}
 
-	newFindingsFilename := fmt.Sprintf("%s.parquet", time.Now().Format("20060102T150405Z"))
-	newFindingsKey := filepath.Join(basepath, newFindingsFilename)
-	if len(newFindings) > 0 {
-		if err := s.createFile(ctx, newFindingsKey, newFindings); err != nil {
-			return oops.Wrapf(err, "failed to write new findings to parquet")
-		}
-	}
-
-	updatedCount := 0
-	for updatedFindingsPath, updatedFindings := range existingFindings {
-		if err := s.updateFile(ctx, updatedFindingsPath, updatedFindings); err != nil {
-			slog.Error("failed to update parquet file", "file", updatedFindingsPath, "error", err)
-			// Fall back to creating a new file for these findings
-
-			newFindingsFilename := fmt.Sprintf("%s.parquet", time.Now().Format("20060102T150405Z"))
-			newFindingsKey := filepath.Join(basepath, newFindingsFilename)
-			if err := s.createFile(ctx, newFindingsKey, updatedFindings); err != nil {
-				return oops.Wrapf(err, "failed to write fallback parquet file")
-			}
-		} else {
-			updatedCount += len(updatedFindings)
-		}
-	}
-
-	slog.Info("saved findings",
-		"new", len(newFindings),
-		"updated", updatedCount)
-
-	return nil
-}
-
-func (s *s3ParquetDatastore) createFile(ctx context.Context, key string, findings []ocsf.VulnerabilityFinding) error {
-	var buf bytes.Buffer
-	writer := io.Writer(&buf)
-	if err := goParquet.Write(writer, findings); err != nil {
-		return oops.Wrapf(err, "failed to write findings to parquet buffer")
-	}
-
-	for _, f := range findings {
-		s.findingIndex[f.FindingInfo.UID] = key
-	}
-
-	_, err := s.s3Client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: &s.s3Bucket,
-		Key:    &key,
-		Body:   bytes.NewReader(buf.Bytes()),
-	})
-	if err != nil {
-		return oops.Wrapf(err, "failed to upload Parquet to S3")
-	}
-
-	slog.Info("Wrote Parquet file to S3",
-		"bucket", s.s3Bucket,
-		"key", key,
-	)
-	return nil
-}
-
-func (s *s3ParquetDatastore) loadFileIntoIndex(ctx context.Context, key string) error {
-	findings, err := s.GetAllFindings(ctx, key)
-	if err != nil {
-		return oops.Wrapf(err, "failed to read all findings from parquet file")
-	}
-
-	for _, finding := range findings {
-		s.findingIndex[finding.FindingInfo.UID] = key
-	}
-
-	slog.Debug("indexed findings from s3", "key", key, "count", len(findings))
-	return nil
-}
-
-func (s *s3ParquetDatastore) updateFile(ctx context.Context, filePath string, updatedFindings []ocsf.VulnerabilityFinding) error {
-	updateMap := make(map[string]ocsf.VulnerabilityFinding)
-	for _, finding := range updatedFindings {
-		updateMap[finding.FindingInfo.UID] = finding
-	}
-
-	allFindings, err := s.GetAllFindings(ctx, filePath)
-	if err != nil {
-		return oops.Wrapf(err, "failed to read all findings from parquet file")
-	}
-
-	for i, finding := range allFindings {
-		if updated, exists := updateMap[finding.FindingInfo.UID]; exists {
-			allFindings[i] = updated
-			slog.Debug("updated finding in memory", "id", finding.FindingInfo.UID)
-		}
+		allFindings = append(allFindings, findings...)
 	}
 
 	var buf bytes.Buffer
@@ -219,19 +121,24 @@ func (s *s3ParquetDatastore) updateFile(ctx context.Context, filePath string, up
 		return oops.Wrapf(err, "failed to write findings to parquet buffer")
 	}
 
-	_, err = s.s3Client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(s.s3Bucket),
-		Key:    aws.String(filePath),
+	_, err := s.s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: &s.s3Bucket,
+		Key:    key,
 		Body:   bytes.NewReader(buf.Bytes()),
 	})
 	if err != nil {
-		return oops.Wrapf(err, "failed to upload updated parquet to S3")
+		return oops.Wrapf(err, "failed to upload Parquet to S3")
 	}
 
-	slog.Info("replaced parquet file in S3",
-		"bucket", s.s3Bucket,
-		"key", filePath,
-		"findings", len(allFindings))
+	for _, f := range allFindings {
+		s.BaseDatastore.findingIndex[f.FindingInfo.UID] = *key
+	}
+	s.BaseDatastore.fileIndex[*key] = len(allFindings)
 
+	slog.Info("Wrote Parquet file to S3",
+		"bucket", s.s3Bucket,
+		"key", *key,
+		"findings", len(allFindings),
+	)
 	return nil
 }

--- a/datastore/s3parquet.go
+++ b/datastore/s3parquet.go
@@ -46,8 +46,7 @@ func NewS3ParquetDatastore(bucketName string, s3Client *s3.Client) Datastore {
 }
 
 // buildFindingIndex builds the datastore's in-memory index of finding IDs to file paths.
-// It reads all Parquet files in the base directory and parses them into a slice of vulnerability findings.
-// The datastore updates its in-memory index with the finding IDs and their corresponding file paths.
+// It reads all Parquet files in the S3 bucket and parses them into a slice of vulnerability findings.
 func (s *s3ParquetDatastore) buildFindingIndex(ctx context.Context) error {
 	paginator := s3.NewListObjectsV2Paginator(s.s3Client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.s3Bucket),
@@ -100,6 +99,8 @@ func (s *s3ParquetDatastore) GetFindingsFromFile(ctx context.Context, key string
 	return findings, nil
 }
 
+// WriteBatch creates a new Parquet file for storing vulnerability findings.
+// It writes the findings to the specified file path and updates the datastore's in-memory index.
 func (s *s3ParquetDatastore) WriteBatch(ctx context.Context, findings []ocsf.VulnerabilityFinding, key *string) error {
 	allFindings := findings
 	if key == nil {

--- a/datastore/types.go
+++ b/datastore/types.go
@@ -10,8 +10,22 @@ import (
 var basepath = "data/findings"
 var ErrNotFound = errors.New("not found")
 
+const maxFileSize = 128 * 1024 * 1024 // 128 MB
+const avgFindingSize = 5 * 1024       // 5 KB, rough estimate
+
+// Datastore defines the interface for vulnerability finding storage.
+// It provides methods to retrieve, save, and manage vulnerability findings.
+// Each implementation of Datastore is responsible for reading and writing to a file, and building the in-memory index of finding IDs to file paths.
 type Datastore interface {
+	// GetFinding retrieves a vulnerability finding by its unique identifier.
 	GetFinding(ctx context.Context, findingID string) (*ocsf.VulnerabilityFinding, error)
-	GetAllFindings(ctx context.Context, path string) ([]ocsf.VulnerabilityFinding, error)
+
+	// GetFindingsFromFile retrieves all vulnerability findings from a specific file path.
+	GetFindingsFromFile(ctx context.Context, path string) ([]ocsf.VulnerabilityFinding, error)
+
+	// SaveFindings saves a list of vulnerability findings to the datastore.
 	SaveFindings(ctx context.Context, findings []ocsf.VulnerabilityFinding) error
+
+	// WriteBatch writes a batch of vulnerability findings to a specific file in a specific format.
+	WriteBatch(ctx context.Context, findings []ocsf.VulnerabilityFinding, path *string) error
 }

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	ctx := context.Background()
 
-	snykClient, err := snyk.NewClient(ctx, snykAPIKey, snykOrganizationID)
+	snykClient, err := snyk.NewClient(snykAPIKey, snykOrganizationID)
 	if err != nil {
 		log.Fatalf("Failed to create Snyk client: %v", err)
 	}

--- a/syncers/snyk.go
+++ b/syncers/snyk.go
@@ -22,6 +22,8 @@ type SnykOCSFSyncer struct {
 	org        *snyk.Org
 }
 
+// NewSnykOCSFSyncer creates a new SnykOCSFSyncer
+// It initializes the Snyk client and datastore, and fetches the organization details.
 func NewSnykOCSFSyncer(ctx context.Context, snykClient *snyk.Client, datastore datastore.Datastore) (DataSync, error) {
 	org, err := snykClient.GetOrg(ctx)
 	if err != nil {
@@ -35,6 +37,8 @@ func NewSnykOCSFSyncer(ctx context.Context, snykClient *snyk.Client, datastore d
 	}, nil
 }
 
+// Sync synchronizes Snyk data with the OCSF datastore
+// It fetches all issues from Snyk, builds OCSF findings, and saves them to the datastore.
 func (s *SnykOCSFSyncer) Sync(ctx context.Context) error {
 	slog.Info("syncing Snyk data")
 
@@ -80,6 +84,7 @@ func (s *SnykOCSFSyncer) Sync(ctx context.Context) error {
 	return nil
 }
 
+// ToOCSF converts a Snyk issue into an OCSF vulnerability finding.
 func (s *SnykOCSFSyncer) ToOCSF(ctx context.Context, issue snyk.Issue, project *snyk.Project, existingFinding *ocsf.VulnerabilityFinding) (ocsf.VulnerabilityFinding, error) {
 	severity, severityID := mapSnykSeverity(issue.Attributes.EffectiveSeverityLevel)
 	status, statusID := mapSnykStatus(issue.Attributes.Status)


### PR DESCRIPTION
Previously, new findings were created in a new file. There were two bugs in this approach:
1. Each new finding was in a unique file
2. Updated findings overwrote the existing finding

This new approach binpacks findings into files of 128M each.

I also documented some functions
